### PR TITLE
add basic file saving and window dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Hiptext
 Minimalist text editor made with Godot 3.5
+
+planned:
+- ~~saving files~~
+- opening files
+- file save/select dialogue
+- moveable window
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Hiptext
 Minimalist text editor made with Godot 3.5
 
+added:
+ctrl+s to save current file as a txt, using the tab name as the filename. it saves where the executable is. I'll improve this sometime soon, but it seems to be working fine
+button left of the minimize that you can hold to drag the window around
+
 planned:
 - ~~saving files~~
 - opening files

--- a/debug_buglist.gd
+++ b/debug_buglist.gd
@@ -11,8 +11,7 @@ onready var tab = $Control/tab/tab.duplicate()
 var size_of_all_tabs_combined = 0
 var tabs = []
 var current_tab_index = 0
-var ms = Vector2.ZERO
-
+var ms = Vector2.ZERO 
 var last_selected_button = null
 var last_selected_button2 = null
 var selected_button = null
@@ -199,6 +198,8 @@ func _physics_process(delta: float) -> void:
 	
 	if Input.is_action_pressed("CTRL") and Input.is_action_just_pressed("T"):
 		add_tab()
+	if Input.is_action_pressed("CTRL") and Input.is_action_just_pressed("S"):
+		save_file()
 	if $Control/tab/add_tab.global_position.distance_squared_to($Control.get_local_mouse_position()) < 100:
 		$Control/tab/add_tab.scale = $Control/tab/add_tab.scale.linear_interpolate(Vector2.ONE / 1.8, delta * 25)
 		$Control/tab/add_tab.modulate = Color.white
@@ -227,6 +228,14 @@ func _physics_process(delta: float) -> void:
 		
 		offset = offset.linear_interpolate(Vector2.ZERO,delta * 15)
 		scale = scale.linear_interpolate(Vector2.ONE,delta * 15)
+
+func save_file():
+	var exec = OS.get_executable_path().get_base_dir()
+	var file = File.new()
+	var name = tabs[current_tab_index].get_node("Label").text
+	file.open(exec + "/" + name + ".txt", File.WRITE)
+	file.store_string($Control/TextEdit.text)
+	file.close()
 
 func add_tab():
 	$Control/TextEdit.readonly = false

--- a/debug_buglist.tscn
+++ b/debug_buglist.tscn
@@ -232,9 +232,9 @@ caret_blink_speed = 0.3
 caret_moving_by_right_click = false
 
 [node name="tab" type="Control" parent="Control"]
-margin_left = 3.0
+margin_left = 15.0
 margin_top = -8.0
-margin_right = 437.0
+margin_right = 449.0
 margin_bottom = 24.0
 rect_clip_content = true
 
@@ -244,7 +244,7 @@ scale = Vector2( 0.5, 0.5 )
 texture = ExtResource( 5 )
 
 [node name="tab" type="Node2D" parent="Control/tab"]
-position = Vector2( 20, 25 )
+position = Vector2( 21, 25 )
 script = ExtResource( 4 )
 
 [node name="ColorRect2" type="ColorRect" parent="Control/tab/tab"]
@@ -344,6 +344,7 @@ clip_text = true
 icon_align = 1
 
 [node name="Button2" type="Button" parent="Control"]
+unique_name_in_owner = true
 margin_left = 436.0
 margin_top = 12.0
 margin_right = 453.0
@@ -360,6 +361,26 @@ custom_styles/focus = SubResource( 29 )
 custom_styles/disabled = SubResource( 15 )
 custom_styles/normal = SubResource( 31 )
 text = "-"
+clip_text = true
+icon_align = 1
+
+[node name="Button3" type="Button" parent="Control"]
+anchor_right = 0.253
+margin_left = 413.0
+margin_top = 12.0
+margin_right = 423.88
+margin_bottom = 22.0
+mouse_filter = 1
+size_flags_horizontal = 0
+size_flags_vertical = 0
+custom_constants/hseparation = 4545
+custom_fonts/font = SubResource( 11 )
+custom_styles/hover = SubResource( 12 )
+custom_styles/pressed = SubResource( 13 )
+custom_styles/focus = SubResource( 30 )
+custom_styles/disabled = SubResource( 15 )
+custom_styles/normal = SubResource( 31 )
+text = "#"
 clip_text = true
 icon_align = 1
 
@@ -401,3 +422,5 @@ text = "
 [connection signal="text_entered" from="Control/tab/tab/Label" to="." method="_on_Label_text_entered"]
 [connection signal="pressed" from="Control/Button" to="." method="_on_Button_pressed"]
 [connection signal="pressed" from="Control/Button2" to="." method="_on_Button2_pressed"]
+[connection signal="button_down" from="Control/Button3" to="." method="_on_Button3_button_down"]
+[connection signal="button_up" from="Control/Button3" to="." method="_on_Button3_button_up"]


### PR DESCRIPTION
from my readme:

added: 
- ctrl+s to save current file as a txt, using the tab name as the filename. it saves where the executable is. I'll improve this sometime soon, but it seems to be working fine. 
- button left of the minimize that you can hold to drag the window around

Feel free to change whatever in this pull request. I'm no expert. 